### PR TITLE
Adding magento2-deployment-tool in tool list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You might be interested in the [Awesome List for Magento 1](https://github.com/D
 - [Pestle](https://github.com/astorm/pestle) - Code Generation Tool by Alan Storm.
 - [Mage2Gen](https://mage2gen.com/) - Online Module Creator.
 - [Magento 2 Code Generator](https://github.com/staempfli/magento2-code-generator) - Code Generator by Juan Alonso.
+- [Magento 2 Deployment Tool](https://github.com/staempfli/magento2-deployment-tool) - Magento2 Deployer by Juan Alonso.
 
 ## Extensions
 


### PR DESCRIPTION
Open source deployment tool for Magento2. It works out of the box, just install and use:

- mg2-deployer setup
- mg2-deployer release