### PR TITLE
Add Deployer recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ ___
 	- **Deployment**
 		- [MageDeploy2](https://github.com/mwr/magedeploy2-base) - Automatic Magento2 Deployments with [robo](http://robo.li/) and [deployer](https://deployer.org/).
 		- [Magento 2 Deployment Tool](https://github.com/staempfli/magento2-deployment-tool) - Magento2 Deployment Tool with [PHing](https://www.phing.info/) by [Juan Alonso](https://commercehero.io/juan.alonso).
+		- [Deployer Magento2 Recipe](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php) - Magento2 deployment recipe for [deployer](https://deployer.org/).
 
 	- **Language Packages**
 


### PR DESCRIPTION
Could also link to Deployer directly, as it contains the magento2 recipe by default. Not sure what's better.