### PR TITLE
Change repository location for sl_SI language pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 - [fi_FL](https://github.com/mageplaza/magento-2-finnish-language-pack) 🇫🇮 - Finnish Language Package.
 - [ko_KR](https://github.com/mageplaza/magento-2-korean-language-pack) 🇰🇷 - Korean Language Package.
 - [sk_SK](https://github.com/mageplaza/magento-2-slovak-language-pack) 🇸🇰 - Slovakian Language Package.
-- [sl_SI](https://github.com/symfony-si/magento2-sl_si) 🇸🇮 - Slovenian Language Package.
+- [sl_SI](https://github.com/symfony-si/magento2-sl-si) 🇸🇮 - Slovenian Language Package.
 
 ### Search
 


### PR DESCRIPTION
Hello, this patch fixes the location for the Slovenian translation since it has been renamed.