### PR TITLE
add magefan blog extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 ### CMS
 
 - [Mageplaza Blog Extension](https://github.com/mageplaza/magento-2-blog-extension) - Simple, but well working Blog Extension.
+- [Magento 2 Blog Extension by Magefan](https://github.com/magefan/module-blog) - Free Blog module for Magento 2 with unlimited blog posts and categories, SEO friendly, lazy load and AMP support.
 - [Bluefoot CMS](https://www.bluefootcms.com/) - CMS Plugin owned by Magento for Magento 2.
 - [PageDesigner](https://github.com/Magenerds/PageDesigner) - Easily create and drag and drop your CMS contents in the Magento Backend.
 


### PR DESCRIPTION
I add Magento 2 Blog Extension by Magefan in the list of Blog-Extension.

I personaly use magefan and mageplaza for adding blog in Magento 2 and magefan have his place in this awesome list.