### PR TITLE
add Painless Magento 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - [Magento 2 PHPStorm File Templates](https://github.com/lfolco/phpstorm-m2-filetemplates) - PHPStorm Magento 2 File Templates.
 - [Magento 2 Composer Repository](https://github.com/EaDesgin/m2-ComposerRepo) - Composer Repository Manager for selling Magento 2 extension and offering composer installation for ordered packages.
 - [MageVulnDB](https://github.com/gwillem/magevulndb) - Central repository for third party Magento extensions with known security issues.
+- [Painless Magento 2](https://github.com/ChacunSonSite/painless-magento2) - A dockerized magento 2 community environment ready for development or production.
 
 ### Deployment
 
@@ -79,6 +80,7 @@
 - [Magento 2 Deployment Tool](https://github.com/staempfli/magento2-deployment-tool) - Magento2 Deployment Tool with PHing by [Juan Alonso](https://commercehero.io/juan.alonso).
 - [Deployer Magento2 Recipe](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php) - Magento2 deployment recipe for [deployer](https://deployer.org/).
 - [Magento 2 Deployer Plus](https://github.com/jalogut/magento2-deployer-plus) - Tool based on deployer.org to perform zero downtime deployments of Magento 2 projects.
+- [Painless Magento 2](https://github.com/ChacunSonSite/painless-magento2) - A dockerized magento 2 community environment ready for development or production.
 
 
 ### Language Packages


### PR DESCRIPTION
Painless Magento 2  It's inspired from dockerize-magento2. 
the principles are:
- Create an enviroment safety, small, fast, easy to use and configurate.
- Keep the magento code independent for the enviroment, for facilitate the use of this containers for development entire magento2 sites or extensions, you ca use then in development, in production or in both.

the advantages are: 
All containers run on Alpine Linux. As a result, the images are smaller, faster and all the containers work with the same rules.

Magento is totally independant from Painless Magento 2. Magento lives inside the src directory. This is a volume in the php container, so you can use Painless Magento 2 to develop stores, websites or Magento extensions. After, you can use the same system for production or take your code from the source directory to use as you need.

Composer runs out the containers. Composer is left outside on purpose to keep the containers small and facilitate their use. You always have access to the code in the volume src. You should use Composer in the host machine. You can apply your changes without stoping the containers. To run compose commands, go to src directory.

ex: install Fooman Goolge Analytics.

 cd src
 composer require fooman/googleanalyticsplus-m2
 cd ..
 bin/console mage setup:upgrade
It includes, alpine latest, php 7,2 , nginx run by socket, mariadb, redis, opcache and let's encrypt; xdebug is only install when the enviroment is set in .env file as developer.

more information in the readme of the project.