### PR TITLE
Add hivecommerce/magento2-content-fuzzyfyr package

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [auroraextensions/simplereturns](https://github.com/auroraextensions/simplereturns) - Self-service RMA for Magento2.
 - [shkoliar/magento-grid-colors](https://github.com/shkoliar/magento-grid-colors) - Magento 2 Grid Colors module for colorizing admin grids. Supports saving of states with the help of grid's bookmarks. by [Dmitry Shkoliar](https://shkoliar.com/)
 - [extdn/extension-dashboard-m2](https://github.com/extdn/extension-dashboard-m2) - A Magento 2 dashboard to display installed extensions. by [Magento Extension Developers Network](https://extdn.org/)
+- [hivecommerce/magento2-content-fuzzyfyr](https://github.com/hivecommerce/magento2-content-fuzzyfyr) - The Content Fuzzyfyr module for Magento2 replaces real content with dummy content. This is for development purposes, e.g. save time to prepare test data and matching GDPR restrictions.
 
 ### Security
 


### PR DESCRIPTION
The Content Fuzzyfyr module for Magento2 replaces real content with dummy content. This can be used to prepare test data easily (e.g. make sure GDPR related data is anonymized).