### PR TITLE
Add Ghost Architect™ Open to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The storefront of Magento 2 can be styled in numerous ways:
 - [Mage Wizard](https://github.com/clickAndMortar/mage-wizard) - Local web UI to view and create automatically modules, plugins, configs, observers, commands, crontabs, etc. directly in Magento 2 codebase
 - [Mage](https://github.com/GrimLink/mage) - Simplifies bin/magento commands by adding helpful shortcuts and time-saving tools to enhance your productivity.
 - [Magento Log Viewer - A Visual Studio Code Extension ](https://marketplace.visualstudio.com/items?itemName=MathiasElle.magento-log-viewer) - Provides a convenient way to view, watch and manage Magento log files and reports directly in your workspace.
+- [Ghost Architect™ Open](https://github.com/EJWisner/ghost-architect-open) — Free AI-powered codebase triage tool. Runs locally, BYOK. Scores findings by severity — Critical, High, Medium, Low. Your code never leaves your machine.
 
 ## Open Source Extensions
 


### PR DESCRIPTION
Ghost Architect™ Open is a free, open-source AI-powered codebase triage tool for Magento 2 and Adobe Commerce developers.

- Runs locally — code never leaves your machine
- Bring your own Anthropic API key (new accounts get a $5 credit)
- Scores findings by severity: Critical, High, Medium, Low
- No signup, no waitlist
- MIT license

Repo: https://github.com/EJWisner/ghost-architect-open