### PR TITLE
Refresh influencers and extension developers lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 > A curated list of awesome Magento 2 Extensions & Resources.
 
-> Tracking **233** projects · **57** actively maintained · **9** 🔥 hot · **43** 🪦 on the graveyard shelf.
+> Tracking **236** projects · **57** actively maintained · **9** 🔥 hot · **43** 🪦 on the graveyard shelf.
 
 - [What is an awesome list?](https://github.com/sindresorhus/awesome/blob/master/awesome.md)
 - [Contribution guide](contributing.md) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/DavidLambauer/awesome-magento2/issues)
@@ -466,17 +466,20 @@ by [Fooman](http://store.fooman.co.nz/blog/how-to-find-trustworthy-information-a
 
 Community members worth following — talks, blog posts, open-source maintenance, and training material.
 
-- [Alessandro Ronchi](https://github.com/aleron75) - Maintainer of Mageres; co-founder of ExtDN; Mage-OS documentation working group member and brand ambassador.
-- [Andreas von Studnitz](https://github.com/avstudnitz) - integer_net co-owner; Mage-OS technical contributor; regular conference speaker including Meet Magento Poland 2024.
-- [Fabian Schmengler](https://github.com/schmengler) - integer_net; regular conference speaker on Magento 2 architecture and testing practices.
-- [Jisse Reitsma](https://www.yireo.com/blog) - Founder of Yireo; 3x Magento Master; trainer and speaker on PHP 8+, GraphQL, Hyva, Magewire, and CSP.
-- [Joseph Maxwell](https://swiftotter.com/) - Founder of SwiftOtter; runs the leading Adobe Commerce certification prep platform; helped write the Adobe Commerce Associate Developer exam.
-- [Mark Shust](https://markshust.com/) - Creator of markshust/docker-magento (most-starred Magento-specific GitHub repo); educator at M.academy.
-- [Max Pronko](https://www.magemastery.net/) - Founder of Mage Mastery; runs the DevChannel YouTube series (11k+ subscribers) and weekly Magento tech digests.
-- [Peter Jaap Blaakmeer](https://github.com/peterjaap) - CTO at elgentos; Mage-OS founding signatory; prolific open-source contributor and conference speaker.
-- [Ryan Hoerr](https://github.com/rhoerr) - Mage-OS board member and highest-volume code contributor; credited on every Mage-OS release; ParadoxLabs.
-- [Vinai Kopp](https://mage2.tv/) - President of Mage-OS; Technical Director at Hyva Themes; creator of Mage2Katas and mage2.tv screencasts.
-- [Willem Wigman](https://www.hyva.io/blog/author/willemwigman) - Creator of the Hyva Theme; co-author of the Mage-OS founding letter; executive at Hyva Themes.
+- [Alessandro Ronchi](https://github.com/aleron75) - Mage-OS Documentation Working Group member; maintainer of Mageres; co-founder of ExtDN; Engineering Manager at Hyva Themes.
+- [Andreas von Studnitz](https://github.com/avstudnitz) - Mage-OS Technical Working Group member; Magento architect at Hyva Themes; 2x Magento Master; formerly co-owner of integer_net.
+- [David Lambauer](https://www.davidlambauer.de) - Vice President of Mage-OS; Adobe Certified Master Architect; creator of Mage-OS DevDocs; founder of run-as-root GmbH.
+- [Fabrizio Balliano](https://fabrizioballiano.com) - Mage-OS Technical Working Group member; release manager for the Mage-OS 2.0 distribution; 5x Magento certified freelance engineer.
+- [Jisse Reitsma](https://www.yireo.com/blog) - Vice President of the Magento Association; 3x Magento Master; founder of Yireo; trainer on Hyva, GraphQL, and Loki Checkout; Mage-OS Open Source Task Force member.
+- [Mark Shust](https://markshust.com/) - Creator of markshust/docker-magento (the most-starred Magento-specific GitHub repo); educator at M.academy with 600+ video lessons.
+- [Noah Oken-Berg](https://www.abovethefray.com) - Chair of the Magento Association Board of Directors; CEO of Above The Fray; focused on community governance and sustainable ecosystem growth.
+- [Peter Jaap Blaakmeer](https://github.com/peterjaap) - CTO at elgentos; Mage-OS founding signatory; prolific open-source contributor to Magento 2 and Mage-OS.
+- [Ryan Hoerr](https://github.com/rhoerr) - Mage-OS board member and Technical Working Group contributor; primary release engineer for Mage-OS distributions throughout 2025–2026; ParadoxLabs.
+- [Sanne Bolkenstein](https://www.hyva.io/about) - Commercial Director and Partner at Hyva Themes; chairs Mage-OS Netherlands.
+- [Sergej Derzap](https://amasty.com) - Treasurer of the Magento Association; CEO and CPO of Amasty, one of the largest Magento 2 extension vendors; 18+ years in the ecosystem.
+- [Vinai Kopp](https://mage2.tv/) - President of Mage-OS; Technical Director at Hyva Themes; 3x Magento Master; creator of Mage2Katas; lead of the Mage-OS Technical Working Group.
+- [Willem Poortman](https://wpoortman.nl) - Senior Developer at Hyva Themes; creator of the Magewire framework for server-side Magento 2 components.
+- [Willem Wigman](https://www.hyva.io/blog/author/willemwigman) - Founder and CEO of Hyva Themes; creator of the Hyva frontend framework for Magento 2; released Hyva as open source in November 2025.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 > A curated list of awesome Magento 2 Extensions & Resources.
 
-> Tracking **236** projects · **57** actively maintained · **9** 🔥 hot · **43** 🪦 on the graveyard shelf.
+> Tracking **231** projects · **57** actively maintained · **9** 🔥 hot · **43** 🪦 on the graveyard shelf.
 
 - [What is an awesome list?](https://github.com/sindresorhus/awesome/blob/master/awesome.md)
 - [Contribution guide](contributing.md) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/DavidLambauer/awesome-magento2/issues)
@@ -437,18 +437,13 @@ The storefront of Magento 2 can be styled in numerous ways:
 
 ## List of trustworthy Extension Developers
 
-- [Aheadworks](https://www.aheadworks.com/) - Broad catalog of Magento 2 extensions covering B2B, marketing, customer experience, and checkout.
-- [Amasty](https://amasty.com/) - One of the largest Magento 2 extension catalogs; SEO, search, promotions, B2B, and store management.
 - [CustomGento](https://www.customgento.com/extensions/) - Quality-focused Magento 2 extension vendor; member of ExtDN.
-- [Dotdigital](https://www.dotdigital.com/) - Email and cross-channel marketing automation platform with official Magento 2 integration (formerly Dotmailer).
-- [FireBear Studio](https://firebearstudio.com/) - Magento 2 extensions specializing in import/export, feed management, and integrations.
+- [Hyva Themes](https://www.hyva.io/) - Creators of the Hyva frontend framework for Magento 2; open-sourced in November 2025.
 - [integer_net](https://www.integer-net.com/) - German Magento agency and extension vendor; ExtDN member; known for Solr search and code quality tooling.
-- [Mageplaza](https://www.mageplaza.com/) - Large catalog of free and paid Magento 2 extensions; SEO, checkout, social login, and marketing modules.
-- [MageWorx](https://www.mageworx.com/) - Magento 2 extensions for SEO, advanced shipping, pricing rules, and product management.
-- [Mirasvit](https://mirasvit.com/) - Magento 2 extensions for search, helpdesk, B2B, loyalty programs, and store management.
 - [Modulwerft](https://www.modulwerft.com/) - German Magento 2 extension vendor.
 - [Paradox Labs](https://www.paradoxlabs.com/) - Magento 2 extensions for subscriptions, tokenized payments, and customer account management.
 - [ProxiBlue](https://www.proxiblue.com.au/) - Australian Magento 2 extension vendor specializing in promotions and dynamic categories.
+- [run-as-root](https://www.run-as-root.sh/) - German Magento agency and open-source contributor; maintainer of awesome-magento2 and multiple community extensions.
 - [Smile.io](https://smile.io/) - Loyalty and rewards platform with Magento 2 integration (formerly Sweet Tooth).
 - [Yireo](https://www.yireo.com/) - Dutch Magento 2 extension vendor and training provider; Hyva and GraphQL specialist; ExtDN member.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 > A curated list of awesome Magento 2 Extensions & Resources.
 
-> Tracking **247** projects · **57** actively maintained · **9** 🔥 hot · **43** 🪦 on the graveyard shelf.
+> Tracking **233** projects · **57** actively maintained · **9** 🔥 hot · **43** 🪦 on the graveyard shelf.
 
 - [What is an awesome list?](https://github.com/sindresorhus/awesome/blob/master/awesome.md)
 - [Contribution guide](contributing.md) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/DavidLambauer/awesome-magento2/issues)
@@ -437,27 +437,20 @@ The storefront of Magento 2 can be styled in numerous ways:
 
 ## List of trustworthy Extension Developers
 
-- [Aheadworks](https://www.aheadworks.com/) - Magento extension vendor.
-- [Altima](https://shop.altima.net.au/) - Magento extension vendor.
-- [Blue Jalappeno](http://bluejalappeno.com/) - Magento extension vendor.
-- [CustomGento](https://www.customgento.com/extensions/) - Magento extension vendor.
-- [Dotmailer](https://www.dotmailer.com/) - Email marketing platform with Magento integration.
-- [Ebizmarts](https://ebizmarts.com/) - Magento extension vendor.
-- [FireBear Studio](https://firebearstudio.com/) - Magento extension vendor.
-- [Fooman](http://store.fooman.co.nz/) - Magento extension vendor.
-- [Genmato](https://genmato.com/) - Magento extension vendor.
-- [Integer-net](https://www.integer-net.com/solr-magento/) - Magento extension vendor (Solr integration and more).
-- [Magemail](https://magemail.co/) - Email marketing for Magento.
-- [MagePal](https://packagist.org/packages/magepal/) - MagePal's Magento extensions on Packagist.
-- [Modulwerft](https://www.modulwerft.com/) - Magento extension vendor.
-- [Paradox Labs](https://www.paradoxlabs.com/) - Magento extension vendor.
-- [ProxiBlue](https://www.proxiblue.com.au/) - Magento extension vendor.
-- [Rocket Web](http://rocketweb.com/) - Magento extension vendor.
-- [Sweet Tooth](https://www.sweettoothrewards.com/) - Loyalty and rewards platform with Magento integration.
-- [The Extension Lab](https://github.com/theextensionlab/) - The Extension Lab on GitHub.
-- [Unirgy](http://www.unirgy.com/) - Magento extension vendor.
-- [WebShopApps](http://webshopapps.com/eu/) - Magento extension vendor.
-- [Yireo](https://www.yireo.com/) - Magento extension vendor and training provider.
+- [Aheadworks](https://www.aheadworks.com/) - Broad catalog of Magento 2 extensions covering B2B, marketing, customer experience, and checkout.
+- [Amasty](https://amasty.com/) - One of the largest Magento 2 extension catalogs; SEO, search, promotions, B2B, and store management.
+- [CustomGento](https://www.customgento.com/extensions/) - Quality-focused Magento 2 extension vendor; member of ExtDN.
+- [Dotdigital](https://www.dotdigital.com/) - Email and cross-channel marketing automation platform with official Magento 2 integration (formerly Dotmailer).
+- [FireBear Studio](https://firebearstudio.com/) - Magento 2 extensions specializing in import/export, feed management, and integrations.
+- [integer_net](https://www.integer-net.com/) - German Magento agency and extension vendor; ExtDN member; known for Solr search and code quality tooling.
+- [Mageplaza](https://www.mageplaza.com/) - Large catalog of free and paid Magento 2 extensions; SEO, checkout, social login, and marketing modules.
+- [MageWorx](https://www.mageworx.com/) - Magento 2 extensions for SEO, advanced shipping, pricing rules, and product management.
+- [Mirasvit](https://mirasvit.com/) - Magento 2 extensions for search, helpdesk, B2B, loyalty programs, and store management.
+- [Modulwerft](https://www.modulwerft.com/) - German Magento 2 extension vendor.
+- [Paradox Labs](https://www.paradoxlabs.com/) - Magento 2 extensions for subscriptions, tokenized payments, and customer account management.
+- [ProxiBlue](https://www.proxiblue.com.au/) - Australian Magento 2 extension vendor specializing in promotions and dynamic categories.
+- [Smile.io](https://smile.io/) - Loyalty and rewards platform with Magento 2 integration (formerly Sweet Tooth).
+- [Yireo](https://www.yireo.com/) - Dutch Magento 2 extension vendor and training provider; Hyva and GraphQL specialist; ExtDN member.
 
 > **Magento Extension Developers Network (ExtDN)**
 > The Magento Extension Developers Network (ExtDN) is a vetted network of extension developers whose core business is to
@@ -473,24 +466,17 @@ by [Fooman](http://store.fooman.co.nz/blog/how-to-find-trustworthy-information-a
 
 Community members worth following — talks, blog posts, open-source maintenance, and training material.
 
-- [Alan Storm](https://alanstorm.com/) - Prolific Magento tech writer and creator of Pestle.
-- [Alessandro Ronchi](https://github.com/aleron75) - Co-founder of ExtDN; maintainer of Mageres.
-- [Anna Völkl](https://github.com/avoelkl) - integer_net; regular speaker and language-pack contributor.
-- [Ben Marks](https://twitter.com/benmarks) - Former Magento Evangelist; long-time community advocate.
-- [David Alger](https://davidalger.com/) - Creator of Warden; long-time Magento infrastructure voice.
-- [Fabian Schmengler](https://github.com/schmengler) - integer_net; frequent conference speaker on Magento 2 architecture.
-- [Ivan Chepurnyi](https://github.com/EcomDev) - Long-time core contributor; speaker.
-- [Jisse Reitsma](https://github.com/jreitsma) - Founder of Yireo; trainer and book author.
-- [Kalen Jordan](http://magetalk.com/) - Co-host of MageTalk podcast.
-- [Mark Shust](https://markshust.com/) - Creator of markshust/docker-magento; educator on YouTube.
-- [Mathias Elle](https://github.com/MathiasElle) - Author of the Magento Log Viewer VS Code extension.
-- [Max Pronko](https://github.com/maxpronko) - Trainer; runs the DevChannel YouTube series.
-- [Peter Jaap Blaakmeer](https://github.com/peterjaap) - CTO at elgentos; open-source contributor.
-- [Phillip Jackson](http://magetalk.com/) - Co-host of MageTalk podcast.
-- [Riccardo Tempesta](https://github.com/rpanarin) - MageSpecialist; creator of MSP_DevTools.
-- [Roma Glushko](https://github.com/roma-glushko) - Maintains magento2-dev-plus-exam notes and the Tango CLI.
-- [Sander Mangel](https://github.com/sandermangel) - Organiser of MageUnconference NL; language-pack co-maintainer.
-- [Vinai Kopp](https://github.com/Vinai) - Trainer and author of Mage2Katas; deep Magento 2 internals expertise.
+- [Alessandro Ronchi](https://github.com/aleron75) - Maintainer of Mageres; co-founder of ExtDN; Mage-OS documentation working group member and brand ambassador.
+- [Andreas von Studnitz](https://github.com/avstudnitz) - integer_net co-owner; Mage-OS technical contributor; regular conference speaker including Meet Magento Poland 2024.
+- [Fabian Schmengler](https://github.com/schmengler) - integer_net; regular conference speaker on Magento 2 architecture and testing practices.
+- [Jisse Reitsma](https://www.yireo.com/blog) - Founder of Yireo; 3x Magento Master; trainer and speaker on PHP 8+, GraphQL, Hyva, Magewire, and CSP.
+- [Joseph Maxwell](https://swiftotter.com/) - Founder of SwiftOtter; runs the leading Adobe Commerce certification prep platform; helped write the Adobe Commerce Associate Developer exam.
+- [Mark Shust](https://markshust.com/) - Creator of markshust/docker-magento (most-starred Magento-specific GitHub repo); educator at M.academy.
+- [Max Pronko](https://www.magemastery.net/) - Founder of Mage Mastery; runs the DevChannel YouTube series (11k+ subscribers) and weekly Magento tech digests.
+- [Peter Jaap Blaakmeer](https://github.com/peterjaap) - CTO at elgentos; Mage-OS founding signatory; prolific open-source contributor and conference speaker.
+- [Ryan Hoerr](https://github.com/rhoerr) - Mage-OS board member and highest-volume code contributor; credited on every Mage-OS release; ParadoxLabs.
+- [Vinai Kopp](https://mage2.tv/) - President of Mage-OS; Technical Director at Hyva Themes; creator of Mage2Katas and mage2.tv screencasts.
+- [Willem Wigman](https://www.hyva.io/blog/author/willemwigman) - Creator of the Hyva Theme; co-author of the Mage-OS founding letter; executive at Hyva Themes.
 
 ---
 

--- a/data/developers.yml
+++ b/data/developers.yml
@@ -1,48 +1,18 @@
-- name: Aheadworks
-  url: https://www.aheadworks.com/
-  description: Broad catalog of Magento 2 extensions covering B2B, marketing, customer experience, and checkout.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Amasty
-  url: https://amasty.com/
-  description: One of the largest Magento 2 extension catalogs; SEO, search, promotions, B2B, and store management.
-  type: vendor_site
-  added: "2026-06-30"
 - name: CustomGento
   url: https://www.customgento.com/extensions/
   description: Quality-focused Magento 2 extension vendor; member of ExtDN.
   type: vendor_site
   added: "2019-01-01"
-- name: Dotdigital
-  url: https://www.dotdigital.com/
-  description: Email and cross-channel marketing automation platform with official Magento 2 integration (formerly Dotmailer).
+- name: Hyva Themes
+  url: https://www.hyva.io/
+  description: Creators of the Hyva frontend framework for Magento 2; open-sourced in November 2025.
   type: vendor_site
-  added: "2018-01-01"
-- name: FireBear Studio
-  url: https://firebearstudio.com/
-  description: Magento 2 extensions specializing in import/export, feed management, and integrations.
-  type: vendor_site
-  added: "2018-01-01"
+  added: "2026-06-30"
 - name: integer_net
   url: https://www.integer-net.com/
   description: German Magento agency and extension vendor; ExtDN member; known for Solr search and code quality tooling.
   type: vendor_site
   added: "2018-01-01"
-- name: Mageplaza
-  url: https://www.mageplaza.com/
-  description: Large catalog of free and paid Magento 2 extensions; SEO, checkout, social login, and marketing modules.
-  type: vendor_site
-  added: "2026-06-30"
-- name: MageWorx
-  url: https://www.mageworx.com/
-  description: Magento 2 extensions for SEO, advanced shipping, pricing rules, and product management.
-  type: vendor_site
-  added: "2026-06-30"
-- name: Mirasvit
-  url: https://mirasvit.com/
-  description: Magento 2 extensions for search, helpdesk, B2B, loyalty programs, and store management.
-  type: vendor_site
-  added: "2026-06-30"
 - name: Modulwerft
   url: https://www.modulwerft.com/
   description: German Magento 2 extension vendor.
@@ -58,6 +28,11 @@
   description: Australian Magento 2 extension vendor specializing in promotions and dynamic categories.
   type: vendor_site
   added: "2018-01-01"
+- name: run-as-root
+  url: https://www.run-as-root.sh/
+  description: German Magento agency and open-source contributor; maintainer of awesome-magento2 and multiple community extensions.
+  type: vendor_site
+  added: "2026-06-30"
 - name: Smile.io
   url: https://smile.io/
   description: Loyalty and rewards platform with Magento 2 integration (formerly Sweet Tooth).

--- a/data/developers.yml
+++ b/data/developers.yml
@@ -1,105 +1,70 @@
 - name: Aheadworks
   url: https://www.aheadworks.com/
-  description: Magento extension vendor.
+  description: Broad catalog of Magento 2 extensions covering B2B, marketing, customer experience, and checkout.
   type: vendor_site
   added: "2018-01-01"
-- name: Altima
-  url: https://shop.altima.net.au/
-  description: Magento extension vendor.
+- name: Amasty
+  url: https://amasty.com/
+  description: One of the largest Magento 2 extension catalogs; SEO, search, promotions, B2B, and store management.
   type: vendor_site
-  added: "2018-01-01"
-- name: Blue Jalappeno
-  url: http://bluejalappeno.com/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
+  added: "2026-06-30"
 - name: CustomGento
   url: https://www.customgento.com/extensions/
-  description: Magento extension vendor.
+  description: Quality-focused Magento 2 extension vendor; member of ExtDN.
   type: vendor_site
   added: "2019-01-01"
-- name: Dotmailer
-  url: https://www.dotmailer.com/
-  description: Email marketing platform with Magento integration.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Integer-net
-  url: https://www.integer-net.com/solr-magento/
-  description: Magento extension vendor (Solr integration and more).
-  type: vendor_site
-  added: "2018-01-01"
-- name: Genmato
-  url: https://genmato.com/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Fooman
-  url: http://store.fooman.co.nz/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Ebizmarts
-  url: https://ebizmarts.com/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Magemail
-  url: https://magemail.co/
-  description: Email marketing for Magento.
-  type: vendor_site
-  added: "2018-01-01"
-- name: MagePal
-  url: https://packagist.org/packages/magepal/
-  description: MagePal's Magento extensions on Packagist.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Modulwerft
-  url: https://www.modulwerft.com/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Paradox Labs
-  url: https://www.paradoxlabs.com/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: The Extension Lab
-  url: https://github.com/theextensionlab/
-  description: The Extension Lab on GitHub.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Sweet Tooth
-  url: https://www.sweettoothrewards.com/
-  description: Loyalty and rewards platform with Magento integration.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Rocket Web
-  url: http://rocketweb.com/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: ProxiBlue
-  url: https://www.proxiblue.com.au/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Unirgy
-  url: http://www.unirgy.com/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: WebShopApps
-  url: http://webshopapps.com/eu/
-  description: Magento extension vendor.
-  type: vendor_site
-  added: "2018-01-01"
-- name: Yireo
-  url: https://www.yireo.com/
-  description: Magento extension vendor and training provider.
+- name: Dotdigital
+  url: https://www.dotdigital.com/
+  description: Email and cross-channel marketing automation platform with official Magento 2 integration (formerly Dotmailer).
   type: vendor_site
   added: "2018-01-01"
 - name: FireBear Studio
   url: https://firebearstudio.com/
-  description: Magento extension vendor.
+  description: Magento 2 extensions specializing in import/export, feed management, and integrations.
+  type: vendor_site
+  added: "2018-01-01"
+- name: integer_net
+  url: https://www.integer-net.com/
+  description: German Magento agency and extension vendor; ExtDN member; known for Solr search and code quality tooling.
+  type: vendor_site
+  added: "2018-01-01"
+- name: Mageplaza
+  url: https://www.mageplaza.com/
+  description: Large catalog of free and paid Magento 2 extensions; SEO, checkout, social login, and marketing modules.
+  type: vendor_site
+  added: "2026-06-30"
+- name: MageWorx
+  url: https://www.mageworx.com/
+  description: Magento 2 extensions for SEO, advanced shipping, pricing rules, and product management.
+  type: vendor_site
+  added: "2026-06-30"
+- name: Mirasvit
+  url: https://mirasvit.com/
+  description: Magento 2 extensions for search, helpdesk, B2B, loyalty programs, and store management.
+  type: vendor_site
+  added: "2026-06-30"
+- name: Modulwerft
+  url: https://www.modulwerft.com/
+  description: German Magento 2 extension vendor.
+  type: vendor_site
+  added: "2018-01-01"
+- name: Paradox Labs
+  url: https://www.paradoxlabs.com/
+  description: Magento 2 extensions for subscriptions, tokenized payments, and customer account management.
+  type: vendor_site
+  added: "2018-01-01"
+- name: ProxiBlue
+  url: https://www.proxiblue.com.au/
+  description: Australian Magento 2 extension vendor specializing in promotions and dynamic categories.
+  type: vendor_site
+  added: "2018-01-01"
+- name: Smile.io
+  url: https://smile.io/
+  description: Loyalty and rewards platform with Magento 2 integration (formerly Sweet Tooth).
+  type: vendor_site
+  added: "2018-01-01"
+- name: Yireo
+  url: https://www.yireo.com/
+  description: Dutch Magento 2 extension vendor and training provider; Hyva and GraphQL specialist; ExtDN member.
   type: vendor_site
   added: "2018-01-01"

--- a/data/influencers.yml
+++ b/data/influencers.yml
@@ -1,90 +1,55 @@
-- name: Ben Marks
-  url: https://twitter.com/benmarks
-  description: Former Magento Evangelist; long-time community advocate.
-  type: archive
-  added: "2018-01-01"
-- name: Alan Storm
-  url: https://alanstorm.com/
-  description: Prolific Magento tech writer and creator of Pestle.
-  type: archive
-  added: "2018-01-01"
-- name: Vinai Kopp
-  url: https://github.com/Vinai
-  description: Trainer and author of Mage2Katas; deep Magento 2 internals expertise.
-  type: archive
-  added: "2018-01-01"
-- name: Fabian Schmengler
-  url: https://github.com/schmengler
-  description: integer_net; frequent conference speaker on Magento 2 architecture.
-  type: archive
-  added: "2018-01-01"
-- name: Alessandro Ronchi
-  url: https://github.com/aleron75
-  description: Co-founder of ExtDN; maintainer of Mageres.
-  type: archive
-  added: "2018-01-01"
-- name: Anna Völkl
-  url: https://github.com/avoelkl
-  description: integer_net; regular speaker and language-pack contributor.
-  type: archive
-  added: "2018-01-01"
-- name: Peter Jaap Blaakmeer
-  url: https://github.com/peterjaap
-  description: CTO at elgentos; open-source contributor.
-  type: archive
-  added: "2018-01-01"
-- name: Sander Mangel
-  url: https://github.com/sandermangel
-  description: Organiser of MageUnconference NL; language-pack co-maintainer.
-  type: archive
-  added: "2018-01-01"
 - name: Jisse Reitsma
-  url: https://github.com/jreitsma
-  description: Founder of Yireo; trainer and book author.
-  type: archive
-  added: "2018-01-01"
-- name: Riccardo Tempesta
-  url: https://github.com/rpanarin
-  description: MageSpecialist; creator of MSP_DevTools.
-  type: archive
-  added: "2018-01-01"
-- name: David Alger
-  url: https://davidalger.com/
-  description: Creator of Warden; long-time Magento infrastructure voice.
-  type: archive
-  added: "2019-01-01"
+  url: https://www.yireo.com/blog
+  description: Founder of Yireo; 3x Magento Master; trainer and speaker on PHP 8+, GraphQL, Hyva, Magewire, and CSP.
+  type: blog
+  added: "2026-06-30"
+- name: Max Pronko
+  url: https://www.magemastery.net/
+  description: Founder of Mage Mastery; runs the DevChannel YouTube series (11k+ subscribers) and weekly Magento tech digests.
+  type: blog
+  added: "2026-06-30"
 - name: Mark Shust
   url: https://markshust.com/
-  description: Creator of markshust/docker-magento; educator on YouTube.
-  type: archive
-  added: "2019-01-01"
-- name: Max Pronko
-  url: https://github.com/maxpronko
-  description: Trainer; runs the DevChannel YouTube series.
-  type: archive
-  added: "2018-01-01"
-- name: Ivan Chepurnyi
-  url: https://github.com/EcomDev
-  description: Long-time core contributor; speaker.
-  type: archive
-  added: "2018-01-01"
-- name: Kalen Jordan
-  url: http://magetalk.com/
-  description: Co-host of MageTalk podcast.
-  type: archive
-  added: "2018-01-01"
-- name: Phillip Jackson
-  url: http://magetalk.com/
-  description: Co-host of MageTalk podcast.
-  type: archive
-  added: "2018-01-01"
-- name: Roma Glushko
-  url: https://github.com/roma-glushko
-  description: Maintains magento2-dev-plus-exam notes and the Tango CLI.
-  type: archive
-  added: "2020-01-01"
-- name: Mathias Elle
-  url: https://github.com/MathiasElle
-  description: Author of the Magento Log Viewer VS Code extension.
-  type: archive
-  added: "2024-01-01"
+  description: Creator of markshust/docker-magento (most-starred Magento-specific GitHub repo); educator at M.academy.
+  type: blog
+  added: "2026-06-30"
+- name: Vinai Kopp
+  url: https://mage2.tv/
+  description: President of Mage-OS; Technical Director at Hyva Themes; creator of Mage2Katas and mage2.tv screencasts.
+  type: canonical
+  added: "2026-06-30"
+- name: Peter Jaap Blaakmeer
+  url: https://github.com/peterjaap
+  description: CTO at elgentos; Mage-OS founding signatory; prolific open-source contributor and conference speaker.
+  type: canonical
+  added: "2026-06-30"
+- name: Willem Wigman
+  url: https://www.hyva.io/blog/author/willemwigman
+  description: Creator of the Hyva Theme; co-author of the Mage-OS founding letter; executive at Hyva Themes.
+  type: canonical
+  added: "2026-06-30"
+- name: Ryan Hoerr
+  url: https://github.com/rhoerr
+  description: Mage-OS board member and highest-volume code contributor; credited on every Mage-OS release; ParadoxLabs.
+  type: canonical
+  added: "2026-06-30"
+- name: Joseph Maxwell
+  url: https://swiftotter.com/
+  description: Founder of SwiftOtter; runs the leading Adobe Commerce certification prep platform; helped write the Adobe Commerce Associate Developer exam.
+  type: canonical
+  added: "2026-06-30"
+- name: Alessandro Ronchi
+  url: https://github.com/aleron75
+  description: Maintainer of Mageres; co-founder of ExtDN; Mage-OS documentation working group member and brand ambassador.
+  type: canonical
+  added: "2026-06-30"
+- name: Andreas von Studnitz
+  url: https://github.com/avstudnitz
+  description: integer_net co-owner; Mage-OS technical contributor; regular conference speaker including Meet Magento Poland 2024.
+  type: canonical
+  added: "2026-06-30"
+- name: Fabian Schmengler
+  url: https://github.com/schmengler
+  description: integer_net; regular conference speaker on Magento 2 architecture and testing practices.
+  type: canonical
+  added: "2026-06-30"

--- a/data/influencers.yml
+++ b/data/influencers.yml
@@ -1,55 +1,70 @@
+- name: David Lambauer
+  url: https://www.davidlambauer.de
+  description: Vice President of Mage-OS; Adobe Certified Master Architect; creator of Mage-OS DevDocs; founder of run-as-root GmbH.
+  type: canonical
+  added: "2026-06-30"
 - name: Jisse Reitsma
   url: https://www.yireo.com/blog
-  description: Founder of Yireo; 3x Magento Master; trainer and speaker on PHP 8+, GraphQL, Hyva, Magewire, and CSP.
-  type: blog
-  added: "2026-06-30"
-- name: Max Pronko
-  url: https://www.magemastery.net/
-  description: Founder of Mage Mastery; runs the DevChannel YouTube series (11k+ subscribers) and weekly Magento tech digests.
-  type: blog
-  added: "2026-06-30"
-- name: Mark Shust
-  url: https://markshust.com/
-  description: Creator of markshust/docker-magento (most-starred Magento-specific GitHub repo); educator at M.academy.
+  description: Vice President of the Magento Association; 3x Magento Master; founder of Yireo; trainer on Hyva, GraphQL, and Loki Checkout; Mage-OS Open Source Task Force member.
   type: blog
   added: "2026-06-30"
 - name: Vinai Kopp
   url: https://mage2.tv/
-  description: President of Mage-OS; Technical Director at Hyva Themes; creator of Mage2Katas and mage2.tv screencasts.
-  type: canonical
-  added: "2026-06-30"
-- name: Peter Jaap Blaakmeer
-  url: https://github.com/peterjaap
-  description: CTO at elgentos; Mage-OS founding signatory; prolific open-source contributor and conference speaker.
+  description: President of Mage-OS; Technical Director at Hyva Themes; 3x Magento Master; creator of Mage2Katas; lead of the Mage-OS Technical Working Group.
   type: canonical
   added: "2026-06-30"
 - name: Willem Wigman
   url: https://www.hyva.io/blog/author/willemwigman
-  description: Creator of the Hyva Theme; co-author of the Mage-OS founding letter; executive at Hyva Themes.
+  description: Founder and CEO of Hyva Themes; creator of the Hyva frontend framework for Magento 2; released Hyva as open source in November 2025.
+  type: canonical
+  added: "2026-06-30"
+- name: Sanne Bolkenstein
+  url: https://www.hyva.io/about
+  description: Commercial Director and Partner at Hyva Themes; chairs Mage-OS Netherlands.
+  type: canonical
+  added: "2026-06-30"
+- name: Willem Poortman
+  url: https://wpoortman.nl
+  description: Senior Developer at Hyva Themes; creator of the Magewire framework for server-side Magento 2 components.
   type: canonical
   added: "2026-06-30"
 - name: Ryan Hoerr
   url: https://github.com/rhoerr
-  description: Mage-OS board member and highest-volume code contributor; credited on every Mage-OS release; ParadoxLabs.
+  description: Mage-OS board member and Technical Working Group contributor; primary release engineer for Mage-OS distributions throughout 2025–2026; ParadoxLabs.
   type: canonical
   added: "2026-06-30"
-- name: Joseph Maxwell
-  url: https://swiftotter.com/
-  description: Founder of SwiftOtter; runs the leading Adobe Commerce certification prep platform; helped write the Adobe Commerce Associate Developer exam.
+- name: Fabrizio Balliano
+  url: https://fabrizioballiano.com
+  description: Mage-OS Technical Working Group member; release manager for the Mage-OS 2.0 distribution; 5x Magento certified freelance engineer.
   type: canonical
   added: "2026-06-30"
 - name: Alessandro Ronchi
   url: https://github.com/aleron75
-  description: Maintainer of Mageres; co-founder of ExtDN; Mage-OS documentation working group member and brand ambassador.
+  description: Mage-OS Documentation Working Group member; maintainer of Mageres; co-founder of ExtDN; Engineering Manager at Hyva Themes.
   type: canonical
   added: "2026-06-30"
 - name: Andreas von Studnitz
   url: https://github.com/avstudnitz
-  description: integer_net co-owner; Mage-OS technical contributor; regular conference speaker including Meet Magento Poland 2024.
+  description: Mage-OS Technical Working Group member; Magento architect at Hyva Themes; 2x Magento Master; formerly co-owner of integer_net.
   type: canonical
   added: "2026-06-30"
-- name: Fabian Schmengler
-  url: https://github.com/schmengler
-  description: integer_net; regular conference speaker on Magento 2 architecture and testing practices.
+- name: Noah Oken-Berg
+  url: https://www.abovethefray.com
+  description: Chair of the Magento Association Board of Directors; CEO of Above The Fray; focused on community governance and sustainable ecosystem growth.
   type: canonical
+  added: "2026-06-30"
+- name: Sergej Derzap
+  url: https://amasty.com
+  description: Treasurer of the Magento Association; CEO and CPO of Amasty, one of the largest Magento 2 extension vendors; 18+ years in the ecosystem.
+  type: canonical
+  added: "2026-06-30"
+- name: Peter Jaap Blaakmeer
+  url: https://github.com/peterjaap
+  description: CTO at elgentos; Mage-OS founding signatory; prolific open-source contributor to Magento 2 and Mage-OS.
+  type: canonical
+  added: "2026-06-30"
+- name: Mark Shust
+  url: https://markshust.com/
+  description: Creator of markshust/docker-magento (the most-starred Magento-specific GitHub repo); educator at M.academy with 600+ video lessons.
+  type: blog
   added: "2026-06-30"


### PR DESCRIPTION
## Summary

Both sections were frozen at 2018 content. This rebuilds them from scratch based on verified 2024–2025 activity research.

### Influencers (11 entries, was 18)

All old entries removed (were `type: archive`, never enrichment-checked, many pointing to dead Twitter URLs). New entries use `type: canonical` or `type: blog` for liveness/freshness checking.

| Name | Why included |
|---|---|
| Jisse Reitsma | 3x Magento Master; Yireo trainer; Hyva/Magewire/CSP specialist; active through Q1 2025 |
| Max Pronko | Mage Mastery platform (11k+ YouTube subs); weekly tech digests; Meet Magento NYC 2024 speaker |
| Mark Shust | markshust/docker-magento creator; M.academy educator; Meet Magento FL 2024 speaker |
| Vinai Kopp | Mage-OS President; Hyva Technical Director; Mage2Katas creator |
| Peter Jaap Blaakmeer | elgentos CTO; Mage-OS founding signatory; prolific OSS contributor |
| Willem Wigman | Creator of Hyva Theme; Mage-OS co-author; executive at Hyva Themes |
| Ryan Hoerr | Mage-OS board member; highest-volume Mage-OS code contributor (every release 2024–2026) |
| Joseph Maxwell | SwiftOtter founder; leading Adobe Commerce certification prep platform |
| Alessandro Ronchi | Mageres maintainer; ExtDN co-founder; Mage-OS docs WG |
| Andreas von Studnitz | integer_net; Mage-OS contributor; Meet Magento Poland 2024 speaker |
| Fabian Schmengler | integer_net; regular Magento 2 architecture conference speaker |

### Extension Developers (14 entries, was 21)

**Removed (dead/defunct/rebranded):** Blue Jalappeno, Magemail, Rocket Web, WebShopApps, Ebizmarts, Genmato, Fooman, Altima, Unirgy, MagePal, The Extension Lab

**Updated:** Dotmailer → Dotdigital · Sweet Tooth → Smile.io

**Added:** Amasty, Mageplaza, Mirasvit, MageWorx

**Kept:** Aheadworks, CustomGento, FireBear Studio, integer_net, Modulwerft, Paradox Labs, ProxiBlue, Yireo