### PR TITLE
Add MageObsidian to Frontends

### DIFF
--- a/data/frontends.yml
+++ b/data/frontends.yml
@@ -37,3 +37,8 @@
   description: "French PWA front-end solution for Magento."
   type: vendor_site
   added: "2019-06-01"
+- name: MageObsidian
+  url: https://github.com/mage-obsidian/module-modern-frontend
+  description: "Open-source Luma replacement using Vite, Vue 3 islands and TailwindCSS 4 on top of native layouts/blocks/templates. Native ESM, HMR, optional Twig engine."
+  type: github_repo
+  added: "2026-07-05"


### PR DESCRIPTION
Adds **[MageObsidian](https://github.com/mage-obsidian/module-modern-frontend)** to the Frontends section (`data/frontends.yml`).

MageObsidian is an open-source (MIT) Luma replacement for Magento 2.4.7+ built on Vite, Vue 3 islands, TailwindCSS 4 and native ESM — while keeping Magento's native Layouts/Blocks/Templates and theme inheritance, so it doesn't require going headless.

**Quality gates:**
- **Generally useful:** fills the gap between Luma (legacy stack) and paid/headless alternatives — modern tooling (Vite HMR, Vue, Tailwind 4) with zero licensing cost and no architectural rewrite.
- **Actively maintained:** regular commits and releases across the org's repos ([mage-obsidian](https://github.com/mage-obsidian)).
- **Stable:** tagged releases published on [Packagist](https://packagist.org/packages/mage-obsidian/module-modern-frontend) and npm.
- **Documented:** bilingual docs site at https://mage-obsidian.jeanmarcos.dev/ (purpose, installation, supported Magento/PHP versions, guides) + a public demo scoring 100/100/100/100 on Lighthouse: https://mage-obsidian-demo.jeanmarcos.dev/

`composer validate-data` passes locally (all data files ✓).

Disclosure: I'm the author of the project.