### PR TITLE
Add Awesome Agentic Commerce to related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ Community members worth following — talks, blog posts, open-source maintenance
 
 - [Awesome PHP](https://github.com/ziadoz/awesome-php) - A curated list of awesome PHP resources.
 - [Mageres](https://github.com/aleron75/mageres) - Alessandro Ronchi's list of resources for Magento 1 and Magento 2.
+- [Awesome Agentic Commerce](https://github.com/MentionNetwork/awesome-agentic-commerce) - Agentic commerce resources across platforms including Adobe Commerce / Magento: UCP, ACP, AP2 and MCP protocols, agent readiness testing and AI-visibility tools.
 
 <details>
 <summary>🪦 Graveyard — projects no longer recommended</summary>


### PR DESCRIPTION
Adds [awesome-agentic-commerce](https://github.com/MentionNetwork/awesome-agentic-commerce) to the "Other Magento 2 related Awesome Lists" section — a curated list for AI-agent-driven commerce (UCP/ACP/AP2/MCP protocols, agent readiness testing, GEO tooling). It covers Adobe Commerce / Magento developer docs alongside the other major platforms, and is relevant to Magento merchants preparing stores for AI shopping agents. Actively maintained with weekly CI link checks.