### PR TITLE
Add BerryPath Guided Selling integration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The storefront of Magento 2 can be styled in numerous ways:
 - [MagePlaza Seo](https://github.com/mageplaza/magento-2-seo-extension) 🫡 - Well-documented multi-purpose SEO Extension.
 - [magento2-withdrawl](https://github.com/Zwernemann/magento2-withdrawl) 🫡 - Magento 2 module providing a compliant EU withdrawal button required from June 19, 2026 (§356a BGB / Directive (EU) 2023/2673). Enables customers and guests to revoke orders via a simple form (name, order number, email), sends automatic confirmation emails, and allows admin management in the backend.
 - [module-blog](https://github.com/mage-os-lab/module-blog) 🫡 - Blog module for Mage-OS / Magento 2 with posts, categories, tags, authors, scheduled publishing, SEO, RSS, sitemap, 6 widgets, and a full GraphQL API. Luma + Hyvä.
+- [BerryPath Guided Selling](https://github.com/BerryPath/magento2-berrypath-flow) - Open source integration for BerryPath. Add interactive product finders and buying guides to Magento 2 storefronts with product synchronization, assisted conversion tracking + Hyvä compatibility.
 
 <details>
 <summary>🪦 Graveyard — projects no longer recommended</summary>


### PR DESCRIPTION
# Added BerryPath Guided Selling integration to the README

## What changed

Added **BerryPath Guided Selling** to the **Marketing** section under **Open Source Extensions**.

## Why

BerryPath is an actively maintained open source Magento 2 integration that helps merchants guide shoppers to the right products through interactive buying guides and personalized product recommendations.

The module includes product feed synchronization, storefront integration for CMS, category and product pages, assisted conversion tracking, and optional Hyvä compatibility. It is well documented, has stable releases, and provides a useful addition to the Marketing section by helping merchants improve product discovery and conversion.
